### PR TITLE
Fixes for Debian and GNU sed

### DIFF
--- a/zsh-yarn-completions.zsh
+++ b/zsh-yarn-completions.zsh
@@ -165,7 +165,7 @@ _yarn_get_workspaces() { # add condition if pwd is not yarn workspace
     # the second sed command removes quotes, spaces, colon, and brace
     for workspace in $(
       echo $object |
-      sed -nE '/".+": {/p' |
+      sed -nE '/".+": \{/p' |
       sed -e 's/^[ "]*//' -e 's/\(": {\)*$//' ||
     ); do
       workspaces+=($workspace)

--- a/zsh-yarn-completions.zsh
+++ b/zsh-yarn-completions.zsh
@@ -153,16 +153,20 @@ _yarn_get_workspaces() { # add condition if pwd is not yarn workspace
   local -a workspaces
   local object
 
+  # get workspace metadata as json object or assign string 'error' to variable
+  # `object`
   object="$(
-    yarn workspaces info || # return json object
-    echo 'error' # print an error to variable
+    yarn workspaces info ||
+    echo 'error'
   )"
 
   if [[ ! $object =~ 'error' ]]; then
+    # the first sed command extracts workspace name keys from the json input;
+    # the second sed command removes quotes, spaces, colon, and brace
     for workspace in $(
-      echo $object | # print object
-      sed -nE '/".+": {/p' | # filters object keys
-      sed -e 's/^[ "]*//' -e 's/\(": {\)*$//' || # removes unnecessary symbols
+      echo $object |
+      sed -nE '/".+": {/p' |
+      sed -e 's/^[ "]*//' -e 's/\(": {\)*$//' ||
     ); do
       workspaces+=($workspace)
     done


### PR DESCRIPTION
Hi, I was excited to find this plugin - the ability to tab complete workspace names is very handy! But it didn't work on my machine out of the box for two reasons:

1. My copy of zsh was not able to parse comments inside subshell expressions.
2. My copy of sed requires that brace literals be escaped in replacement expressions.

I don't know if this is actually a Debian / GNU issue. FWIW I'm running,

- Debian Testing
- zsh 5.8 (x86_64-debian-linux-gnu)
- sed (GNU sed) 4.7

I removed comments from subshell expressions, and replaced them with larger comments before the expression. I also added a backslash in a sed command to escape a curly brace.