### PR TITLE
Fix workspace subcommand

### DIFF
--- a/zsh-yarn-completions.zsh
+++ b/zsh-yarn-completions.zsh
@@ -85,7 +85,7 @@ _yarn_get_scripts_from_workspace_package_json() {
   [[ "$package_json" = "" ]] && return
 
   options=(
-    ${(f)$(_yarn_parse_package_json_for_script_suggestions $package_json)} \
+    ${(f)"$(_yarn_parse_package_json_for_script_suggestions $package_json)"} \
     env:"Prints list of environment variables available to the scripts at runtime" \
   )
 

--- a/zsh-yarn-completions.zsh
+++ b/zsh-yarn-completions.zsh
@@ -317,7 +317,7 @@ _yarn_workspace_commands() {
   _alternative \
     "global-commands:global:_yarn_global_commands" \
     "common-workspace-commands:workspace:_yarn_common_workspace_commands" \
-    "package-scripts:scripts:_yarn_get_scripts_from_workspace_package_json" \;
+    "package-scripts:scripts:_yarn_get_scripts_from_workspace_package_json"\;
 }
 
 _yarn_common_flags() {


### PR DESCRIPTION
## How about this?
Fixes #5 and another `workspace` subcommand problem.

### another problem
When there are multiple scripts definitions, they are all merged into one.

for example:
```
{
    :
  "scripts": {
    "start:dev": "next dev",
    "start:prod": "next start"
  }
}
```

completion:
```
$ yarn workspace thisisworkspace [TAB]
start:dev  -- $ next dev start:prod:$ next start prestart:prod:$ yarn build
```

expected:
```
$ yarn workspace thisisworkspace [TAB]
start:dev  -- $ next dev
start:prod -- $ next start
```

## Environment
Zsh: 5.8
OS: macOS 11.3.1