### PR TITLE
restore aliases

### DIFF
--- a/zsh-yarn-completions.plugin.zsh
+++ b/zsh-yarn-completions.plugin.zsh
@@ -1,2 +1,3 @@
 0=${(%):-%N}
+source ${0:A:h}/zsh-yarn-aliases.zsh
 source ${0:A:h}/zsh-yarn-completions.zsh


### PR DESCRIPTION
yarn aliases aren't getting loaded by the zsh plugin but should be